### PR TITLE
Exclusively use NetworkManager for service name.

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -35,7 +35,7 @@ wifi_connect () {
         reset_nm
         sleep 1
 
-        service network-manager start; nmcli device set ${WIFI_ADAPTER} managed yes  # Make sure we turn on managed mode again in case we didn't recover it in the trap below
+        service NetworkManager start; nmcli device set ${WIFI_ADAPTER} managed yes  # Make sure we turn on managed mode again in case we didn't recover it in the trap below
         nmcli radio wifi off
         sleep 1
         nmcli radio wifi on

--- a/run_detach.sh
+++ b/run_detach.sh
@@ -19,8 +19,8 @@ source common_run.sh
 # Cutting device from cloud, allowing local-tuya access still
 echo "Cutting device off from cloud.."
 echo "==> Wait for 20-30 seconds for the device to connect to 'cloudcutterflash'. This script will then show the activation requests sent by the device, and tell you whether local activation was successful."
-nmcli device set ${WIFI_ADAPTER} managed no; service network-manager stop;
-trap "service network-manager start; nmcli device set ${WIFI_ADAPTER} managed yes" EXIT  # Set WiFi adapter back to managed when the script exits
+nmcli device set ${WIFI_ADAPTER} managed no; service NetworkManager stop;
+trap "service NetworkManager start; nmcli device set ${WIFI_ADAPTER} managed yes" EXIT  # Set WiFi adapter back to managed when the script exits
 INNER_SCRIPT=$(xargs -0 <<- EOF
 	# This janky looking string substitution is because of double evaluation.
 	# Once in the parent shell script, and once in this heredoc used as a shell script.


### PR DESCRIPTION
network-manager is the package name, but the service name is NetworkManager.  Some systems link them together, but some don't.