### PR TITLE
Stringify timestamp

### DIFF
--- a/src/cloudcutter/protocol/handlers.py
+++ b/src/cloudcutter/protocol/handlers.py
@@ -129,7 +129,7 @@ class OTAFilesHandler(tornado.web.StaticFileHandler):
         total = self.get_content_size()
         timestamp = ""
         if self.verbose_output:
-            timestamp = datetime.datetime.now().time() + " "
+            timestamp = str(datetime.datetime.now().time()) + " "
         print(f"[{timestamp}Firmware Upload] {self.request.uri} send complete, request range: {range_value}/{total}")
 
 


### PR DESCRIPTION
When flashing a Jasco Enbrighten WFD4105 device with `sudo ./tuya-cloudcutter.sh -w wlx681ca2160b50 -f OpenBK7231N_UG_1.15.547.bin -v 2>&1 | tee log.txt`, I got an error reported during the flashing process. Allegedly it successfully flashed, but it probably shouldn't have this error.

I got:
```
Traceback (most recent call last):
  File "/src/.venv/lib/python3.9/site-packages/tornado/web.py", line 1715, in _execute
    self.finish()
  File "/src/.venv/lib/python3.9/site-packages/tornado/web.py", line 1163, in finish
    self.on_finish()
  File "/src/cloudcutter/protocol/handlers.py", line 132, in on_finish
    timestamp = datetime.datetime.now().time() + " "
TypeError: unsupported operand type(s) for +: 'datetime.time' and 'str'
```

So I think we need to make this a string first.