### PR TITLE
fix: lumary uses 192.168.176.1 gw

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -82,7 +82,8 @@ wifi_connect () {
         # There does not appear to be a numeric status code we can check
         # This may need updating if Tuya or one of their sub-vendors ever change their AP mode gateway IP
         AP_GATEWAY=$(nmcli -f IP4.GATEWAY con show "${AP_MATCHED_NAME}" | awk -F ' ' '{print $2}')
-        if [ "${AP_GATEWAY}" != "192.168.175.1" ]; then
+        if [ "${AP_GATEWAY}" != "192.168.175.1" ] && [ "${AP_GATEWAY}" != "192.168.176.1" ]; then
+            echo "Expected AP gateway = 192.168.175.1 or 192.168.176.1 but got ${AP_GATEWAY}"
             if [[ "${i}" == "5" ]]; then
                 echo "Error, could not connect to SSID."
                 return 1


### PR DESCRIPTION
This PR adds support for a 192.168.176.1, which I observed being used on the Lumary light running exploitable firmware 1.3.21 described in #335. 

It also logs the gateway used if it was incorrect for debugging.