### PR TITLE
Set python to 3.9.12 to support armv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster AS base
+FROM python:3.9.12-slim-buster AS base
 
 RUN apt-get -qq update && apt-get install -qy --no-install-recommends git hostapd rfkill dnsmasq build-essential libssl-dev iproute2 mosquitto
 


### PR DESCRIPTION
<img width="1248" alt="image" src="https://user-images.githubusercontent.com/242763/233411562-5ad69e73-cbde-4574-989d-37fc16e45886.png">
Starting with 3.9.13, the python containers stopped supporting armv6. I had an old Pi Zero W that I used for Tuya-Convert back in the day that I wanted to try this on, and had to make this change to get it to work. Worked fine, and now I have a power strip running libretuya-esphome.