### PR TITLE
Dropping nmcli reqs

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -2,19 +2,17 @@
 
 AP_MATCHED_NAME=""
 AP_CONNECTED_ENDING=""
-FIRST_WIFI=$(nmcli device status | grep " wifi " | head -n1 | awk -F ' ' '{print $1}')
 
 if [ "${WIFI_ADAPTER}" == "" ]; then
-  WIFI_ADAPTER="${FIRST_WIFI}"
-fi
-
-if [ "${WIFI_ADAPTER}" == "" ]; then
+  WIFI_ADAPTER=$(sudo iw dev | grep -m 1 -oP "Interface \K.*")
+  if [ "${WIFI_ADAPTER}" == "" ]; then
 	echo "[!] Unable to auto-detect wifi adapter.  Please use the '-w' argument to pass in a wifi adapter."
 	echo "See '$0 -h' for more information."
 	exit 1
+  fi
 fi
 
-SUPPORTS_AP=$(nmcli -f wifi-properties device show ${WIFI_ADAPTER} | grep WIFI-PROPERTIES.AP | awk -F ' ' '{print $2}')
+SUPPORTS_AP=$(iw phy phy$(iw dev ${WIFI_ADAPTER} info | grep -oP "wiphy \K\d+") info | grep -q "AP" && echo "yes")
 
 # We don't want to hard stop here because localization could lead to false positives, but warn if AP mode does not appear supported.
 if [ "${SUPPORTS_AP}" != "yes" ]; then
@@ -54,10 +52,9 @@ wifi_connect () {
         reset_nm
         sleep 1
 
-        service NetworkManager start; nmcli device set ${WIFI_ADAPTER} managed yes  # Make sure we turn on managed mode again in case we didn't recover it in the trap below
-        nmcli radio wifi off
+        sudo ip link set dev ${WIFI_ADAPTER} down
         sleep 1
-        nmcli radio wifi on
+        sudo ip link set dev ${WIFI_ADAPTER} up
         while [ "${AP_MATCHED_NAME}" == "" ]
         do
             if [ ${FIRST_RUN} == true ]; then
@@ -66,11 +63,6 @@ wifi_connect () {
             else
                 echo -n "."
             fi
-            
-            RESCAN_ARG="--rescan yes"
-            if [ "${DISABLE_RESCAN}" == "true" ]; then
-                RESCAN_ARG=""
-            fi
 
             # Search for an AP ending with - and 4 hexidecimal characters that has no security mode, unless we've already connected to one, in which case we look for that specific one
             SSID_REGEX="-[A-F0-9]{4}"
@@ -78,17 +70,23 @@ wifi_connect () {
                 SSID_REGEX="${AP_CONNECTED_ENDING}"
             fi
 
-            AP_MATCHED_NAME=$(nmcli -t -f SSID,SECURITY dev wifi list ${RESCAN_ARG} ifname ${WIFI_ADAPTER} | grep -E ^.*${SSID_REGEX}:$ | awk -F ':' '{print $1}' | head -n1)
+            AP_MATCHED_NAME=$(sudo iw ${WIFI_ADAPTER} scan | grep -oP "SSID: \K.*$SSID_REGEX")
         done
 
         echo -e "\nFound access point name: \"${AP_MATCHED_NAME}\", trying to connect..."
-        nmcli dev wifi connect "${AP_MATCHED_NAME}" ifname ${WIFI_ADAPTER} name "${AP_MATCHED_NAME}"
+        sudo iw dev ${WIFI_ADAPTER} connect "${AP_MATCHED_NAME}"
+        until iw dev ${WIFI_ADAPTER} link | grep -qP "SSID: ${AP_MATCHED_NAME}"; do
+             echo -n "."
+             sleep 2
+        done
+        echo ""
+        sudo dhclient -v -1 ${WIFI_ADAPTER}
 
         # Check if successfully connected
         # Note, we were previously checking GENERAL.STATE and comparing to != "activated" but that has internationalization problems
         # There does not appear to be a numeric status code we can check
         # This may need updating if Tuya or one of their sub-vendors ever change their AP mode gateway IP
-        AP_GATEWAY=$(nmcli -f IP4.GATEWAY con show "${AP_MATCHED_NAME}" | awk -F ' ' '{print $2}' | grep -o 192\.168\.17[65]\.1)
+        AP_GATEWAY=$(ip route show dev ${WIFI_ADAPTER} | grep -oP "default via \K\S+")
         if [ "${AP_GATEWAY}" != "192.168.175.1" ] && [ "${AP_GATEWAY}" != "192.168.176.1" ]; then
             if [ "${AP_GATEWAY}" != "" ]; then
                 echo "Expected AP gateway = 192.168.175.1 or 192.168.176.1 but got ${AP_GATEWAY}"

--- a/common.sh
+++ b/common.sh
@@ -70,7 +70,7 @@ wifi_connect () {
                 SSID_REGEX="${AP_CONNECTED_ENDING}"
             fi
 
-            AP_MATCHED_NAME=$(sudo iw ${WIFI_ADAPTER} scan | grep -oP "SSID: \K.*$SSID_REGEX")
+            AP_MATCHED_NAME=$(sudo iw ${WIFI_ADAPTER} scan flush | grep -oP "SSID: \K.*$SSID_REGEX")
         done
 
         echo -e "\nFound access point name: \"${AP_MATCHED_NAME}\", trying to connect..."

--- a/common_run.sh
+++ b/common_run.sh
@@ -105,7 +105,8 @@ echo "Long press the power/reset button on the device until it starts fast-blink
 echo "See https://support.tuya.com/en/help/_detail/K9hut3w10nby8 for more information."
 echo "================================================================================"
 echo ""
-sleep 5
+echo "Press ENTER when ready..." && read
+
 run_helper_script "pre-wifi-config"
 wifi_connect
 if [ ! $? -eq 0 ]; then

--- a/common_run.sh
+++ b/common_run.sh
@@ -105,7 +105,6 @@ echo "Long press the power/reset button on the device until it starts fast-blink
 echo "See https://support.tuya.com/en/help/_detail/K9hut3w10nby8 for more information."
 echo "================================================================================"
 echo ""
-echo "Press ENTER when ready..." && read
 
 run_helper_script "pre-wifi-config"
 wifi_connect

--- a/safety_checks.sh
+++ b/safety_checks.sh
@@ -5,7 +5,7 @@ check_port () {
 	port="$2"
 	reason="$3"
 	echo -n "Checking ${protocol^^} port $port... "
-	process_pid=$(sudo ss -lnp -A "$protocol" "sport = :$port" | grep -Po "(?<=pid=)(\d+)" | head -n1)
+	process_pid=$(sudo ss -lnp -A "$protocol" "sport = :$port" | grep -m1 -Po "(?<=pid=)(\d+)")
 	if [ -n "$process_pid" ]; then
 		process_name=$(ps -p "$process_pid" -o comm=)
 		echo "Occupied by $process_name with PID $process_pid."

--- a/src/setup_apmode.sh
+++ b/src/setup_apmode.sh
@@ -15,7 +15,7 @@ LOG_OPTIONS=""
 if [ "${VERBOSE_OUTPUT}" == "true" ]; then
         LOG_OPTIONS="--log-dhcp --log-queries --log-facility=/dev/stdout"
 fi
-dnsmasq --no-resolv --interface=$WLAN --bind-interfaces --listen-address=$GATEWAY --except-interface=lo --dhcp-range=10.42.42.10,10.42.42.40,12h --address=/#/${GATEWAY} -x $(pwd)/dnsmasq.pid $LOG_OPTIONS
+dnsmasq --no-resolv --interface=$WLAN --bind-interfaces --listen-address=$GATEWAY --except-interface=lo --dhcp-range=10.42.42.10,10.42.42.40,12h --address=/#/${GATEWAY} $LOG_OPTIONS
 
 mkdir /run/mosquitto
 chown mosquitto /run/mosquitto
@@ -28,7 +28,7 @@ rfkill unblock wifi
 # 1. 802.11n in 2.4GHz (hw_mode=g) - some devices scan for it
 # 2. WPA2-PSK - some devices do not connect otherwise
 # 3. Enforced WPA2 - same as above
-hostapd /dev/stdin -P $(pwd)/hostapd.pid -B <<- EOF
+hostapd /dev/stdin -B <<- EOF
 ssid=cloudcutterflash
 channel=1
 logger_stdout_level=4

--- a/tuya-cloudcutter.sh
+++ b/tuya-cloudcutter.sh
@@ -106,8 +106,8 @@ if [ $METHOD_DETACH ]; then
 	echo "================================================================================"
 	echo ""
 
-	nmcli device set ${WIFI_ADAPTER} managed no; service NetworkManager stop;
-	trap "service NetworkManager start; nmcli device set ${WIFI_ADAPTER} managed yes" EXIT  # Set WiFi adapter back to managed when the script exits
+	#nmcli device set ${WIFI_ADAPTER} managed no; service NetworkManager stop;
+	#trap "service NetworkManager start; nmcli device set ${WIFI_ADAPTER} managed yes" EXIT  # Set WiFi adapter back to managed when the script exits
 	INNER_SCRIPT=$(xargs -0 <<- EOF
 		# This janky looking string substitution is because of double evaluation.
 		# Once in the parent shell script, and once in this heredoc used as a shell script.
@@ -137,8 +137,8 @@ if [ $METHOD_FLASH ]; then
 	echo "Wait for up to 10-120 seconds for the device to connect to 'cloudcutterflash'. This script will then show the firmware upgrade requests sent by the device."
 	echo "================================================================================"
 	echo ""
-	nmcli device set "${WIFI_ADAPTER}" managed no
-	trap "nmcli device set ${WIFI_ADAPTER} managed yes" EXIT  # Set WiFi adapter back to managed when the script exits
+	#nmcli device set "${WIFI_ADAPTER}" managed no
+	#trap "nmcli device set ${WIFI_ADAPTER} managed yes" EXIT  # Set WiFi adapter back to managed when the script exits
 	run_in_docker bash -c "bash /src/setup_apmode.sh ${WIFI_ADAPTER} ${VERBOSE_OUTPUT} && pipenv run python3 -m cloudcutter update_firmware \"${PROFILE}\" \"/work/device-profiles/schema\" \"${CONFIG_DIR}\" \"/work/custom-firmware/\" \"${FIRMWARE}\" \"${FLASH_TIMEOUT}\" \"${VERBOSE_OUTPUT}\""
 	if [ ! $? -eq 0 ]; then
 		echo "Oh no, something went wrong with updating firmware! Try again I guess..."

--- a/tuya-cloudcutter.sh
+++ b/tuya-cloudcutter.sh
@@ -106,8 +106,6 @@ if [ $METHOD_DETACH ]; then
 	echo "================================================================================"
 	echo ""
 
-	#nmcli device set ${WIFI_ADAPTER} managed no; service NetworkManager stop;
-	#trap "service NetworkManager start; nmcli device set ${WIFI_ADAPTER} managed yes" EXIT  # Set WiFi adapter back to managed when the script exits
 	INNER_SCRIPT=$(xargs -0 <<- EOF
 		# This janky looking string substitution is because of double evaluation.
 		# Once in the parent shell script, and once in this heredoc used as a shell script.
@@ -137,8 +135,7 @@ if [ $METHOD_FLASH ]; then
 	echo "Wait for up to 10-120 seconds for the device to connect to 'cloudcutterflash'. This script will then show the firmware upgrade requests sent by the device."
 	echo "================================================================================"
 	echo ""
-	#nmcli device set "${WIFI_ADAPTER}" managed no
-	#trap "nmcli device set ${WIFI_ADAPTER} managed yes" EXIT  # Set WiFi adapter back to managed when the script exits
+
 	run_in_docker bash -c "bash /src/setup_apmode.sh ${WIFI_ADAPTER} ${VERBOSE_OUTPUT} && pipenv run python3 -m cloudcutter update_firmware \"${PROFILE}\" \"/work/device-profiles/schema\" \"${CONFIG_DIR}\" \"/work/custom-firmware/\" \"${FIRMWARE}\" \"${FLASH_TIMEOUT}\" \"${VERBOSE_OUTPUT}\""
 	if [ ! $? -eq 0 ]; then
 		echo "Oh no, something went wrong with updating firmware! Try again I guess..."


### PR DESCRIPTION
Currently the code is tightly tied to having a working NetworkManager, but there are many distributions that do not use it. This PR replaces the NetworkManager commands with base ip / iw / ss / ... commands, widely available in almost all linux distros.