### PR TITLE
#796: Choose AP channel by the wifi device

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9.18-slim-bullseye AS base
 
-RUN apt-get -qq update && apt-get install -qy --no-install-recommends git hostapd rfkill dnsmasq build-essential libssl-dev iproute2 mosquitto
+RUN apt-get -qq update && apt-get install -qy --no-install-recommends git hostapd rfkill dnsmasq build-essential libssl-dev iproute2 mosquitto iw
 
 FROM base AS python-deps
 

--- a/src/setup_apmode.sh
+++ b/src/setup_apmode.sh
@@ -64,9 +64,13 @@ rfkill unblock wifi
 # 2. WPA2-PSK - some devices do not connect otherwise
 # 3. Enforced WPA2 - same as above
 # 4. Channel parsed from wlan device info or 1 as fallback
-
 AP_CHANNEL=$(get_ap_channel "$WLAN")
-echo "Using hostapd channel $AP_CHANNEL parsed from $WLAN info (\`iw $WLAN info\`)."
+if [[ $? -eq 0 ]]; then
+        echo "Using hostapd channel $AP_CHANNEL parsed from wlan info."
+else
+        AP_CHANNEL="1"
+        echo "Unable to get channel from wlan info. Using $AP_CHANNEL as fallback."
+fi
 hostapd /dev/stdin -P $(pwd)/hostapd.pid -B <<- EOF
 ssid=cloudcutterflash
 channel=$AP_CHANNEL


### PR DESCRIPTION
Try to get the channel for hostapd AP from `iw dev <devname> info`.
Initial attemp with used `$WLAN` directly but if the channel is not found there, it finds the other interface with same wiphy (parent device of virtual interface) and tries to get it from there