### PR TITLE
Adjust docker privileges to avoid permission problem creating PID files

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -128,7 +128,7 @@ build_docker() {
 
 run_in_docker() {
     docker rm cloudcutter >/dev/null 2>&1
-    docker run --rm --name cloudcutter --network=host -ti --privileged -v "$(pwd):/work" cloudcutter "${@}"
+    docker run --rm --name cloudcutter --network=host -ti --cap-add=NET_ADMIN --cap-add=SYS_ADMIN --device=/dev/rfkill:/dev/rfkill -v "$(pwd):/work" cloudcutter "${@}"
 }
 
 # Docker prep


### PR DESCRIPTION
which is really weird but I could not workaround otherwise. I guess, it is because my host system (openSUSE Tumbleweed) uses different numeric user/group IDs than Debian.

Now, this bit me by mosquitto silently failing because it "could not" create its PID file.

This probably supersedes my previous PR but I honestly did not try...
