### PR TITLE
Bullseye to Bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.18-slim-bullseye AS base
+FROM python:3.9.18-slim-bookworm AS base
 
 RUN apt-get -qq update && apt-get install -qy --no-install-recommends git hostapd rfkill dnsmasq build-essential libssl-dev iproute2 mosquitto iw
 


### PR DESCRIPTION
Bullseye is no longer supported, and packages are no longer available. The tool works without issue with bookworm